### PR TITLE
ID updates for Jenkins integration guide

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -113,7 +113,7 @@ oc apply -f test-build-pipeline.yaml -n Kabanero
 
 In the command, the `-n` indicates the Kabanero namespace where the pipeline is created.
 
-=== Create the PipelineRun binary
+=== Create a PipelineRun binary
 *Note:* You can use a project of your choice to complete this guide. If you don’t have a project yet, run the `appsody init nodejs-express` command to get a sample Node.js - Express application.
 
 Go to the Kabanero Foundation project that you cloned and open the `scripts/appsody-Tekton-example-manual-run.sh` file. In this file, edit the `DOCKER_IMAGE` and `APP_REPO` parameters to reflect the code repository and image repository of your choice. For this example, use the Docker repository on OpenShift.

--- a/README.adoc
+++ b/README.adoc
@@ -144,7 +144,7 @@ oc get pipelinerun
 
 Run the following command to display the PipelineRun execution steps:
 ----
-oc get pipelinerun-o yaml
+oc get pipelinerun -o yaml
 ----
 
 If the `pipeline-run` command fails at `validate-collection-is-activestep`, remove the `appsody/nodejs-express:<ver>` value and add the `Kabanero/nodejs-express:<ver>` value in the `appsody-config.yaml` file under the Appsody project.

--- a/README.adoc
+++ b/README.adoc
@@ -70,7 +70,7 @@ spec:
   tasks:
     - name: build-task
       taskRef:
-        name: CollectiionId-build-task
+        name: CollectionId-build-task
       resources:
       inputs:
         - name: git-source

--- a/README.adoc
+++ b/README.adoc
@@ -45,7 +45,7 @@ You need the following prerequisites to complete the guide:
 See each project's documentation for necessary system requirements.
 
 == Intended audience
-This guide is for anyone who has experience with Jenkins and is familiar with the fundamental concepts of microservices, Docker, Kubernetes, OpenShift, and Tekton. The purpose of the guide is to show an existing Jenkins user or administrator how to build an image by using Tekton and how to deploy an image with Jenkins.
+This guide is for anyone who has experience with Jenkins and is familiar with the fundamental concepts of microservices, Docker, Kubernetes, OpenShift, and Tekton. The purpose of the guide is to show an existing Jenkins user or administrator how to build an image with Tekton and how to deploy an image with Jenkins.
 
 == Build an image with Tekton
 

--- a/README.adoc
+++ b/README.adoc
@@ -1,1 +1,179 @@
+---
+permalink: /guides/jenkins-integration-with-kabanero/
+---
+:page-layout: guide
+:page-duration: 30 minutes
+:page-releasedate: 2019-10-24
+:page-description: Learn how to use Tekton to build an image and how to use Jenkins to deploy an application that uses that image.
+:page-tags: ['Tekton', 'Jenkins', 'CI/CD', 'Collection']
+:page-guide-category: collections
+:source-highlighter: pygments
+= Jenkins integration with Kabanero
 
+Learn how to use Tekton to build an image and how to use Jenkins to deploy an application that uses that image.
+
+The following diagram depicts the relationship and flow between Tekton and Jenkins:
+
+image::/img/guide/jenkins-tekton.png[link="/img/guide/jenkins-tekton.png" alt=""]
+
+== Prerequisites
+You need the following prerequisites to complete the guide:
+
+// OKD Installation - At the time this guide is written, 3.11 is the preferred version.
+* link:https://docs.okd.io/latest/install/running_install.html[OpenShift 3.11]
+// Kabanero Foundation
+* link:https://github.com/Kabanero-io/Kabanero-foundation[Kabanero Foundation] (cloned)
+// Kabanero Pipelines
+* link:https://github.com/Kabanero-io/Kabanero-pipelines[Kabanero Pipelines] (cloned)
+// Appsody Installation
+* link:http://appsody.dev[Appsody] (installed)
+
+See each project's documentation for necessary system requirements.
+
+== Intended audience
+This guide is for anyone who has experience with Jenkins and is familiar with the fundamental concepts of microservices, Docker, Kubernetes, OpenShift, and Tekton. The purpose of the guide is to show an existing Jenkins user or administrator how to build an image by using Tekton and how to deploy an image with Jenkins.
+
+== Build an image with Tekton
+
+=== Create a pipeline
+The script to create a pipeline is included with the Kabanero Pipelines project. This template script contains both build and deployment tasks, but you will remove the deployment task from the file so that Tekton performs only the build task.
+
+Go to the `kabanero-pipelines` folder that you recently cloned. Find the `pipelines/incubator/build-deploy-pipeline.yaml` file, and remove the section of the file that is highlighted:
+
+// image::/img/guide/test-build-pipeline.png[link="/img/guide/test-build-pipeline.png" alt=""]
+[source,yaml,highlight=68..77]
+----
+apiVersion: Tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: CollectionId-build-deploy-pipeline
+spec:
+  resources:
+    - name: git-source
+      type: git
+    - name: docker-image
+      type: image
+  tasks:
+    - name: build-task
+      taskRef:
+        name: CollectiionId-build-task
+      resources:
+      inputs:
+        - name: git-source
+          resource: git-source
+      outputs:
+        - name: docker-image
+          resource: docker-image
+    - name: deploy-task
+      taskRef:
+        name: CollectionId-deploy-task
+      runAfter: [build-task]
+      resources:
+        inputs:
+        - name: git-source
+          resource: git-source
+        - name: docker-image
+          resource: docker-image
+----
+
+You removed the deployment task. Save and close the file. Rename the file to `test-build-pipeline.yaml`.
+
+In the `test-build-pipeline.yaml` file, update the name of the build task to `nodejs-express-build-task`. The taskRef name must be one of the tasks that is installed in the OpenShift cluster. Then, update the pipeline name to `test-build-pipeline`. After you make these changes, your file looks like following example:
+
+// image::/img/guide/build-task.png[link="/img/guide/build-task.png" alt=""]
+[source,yaml]
+----
+apiVersion: Tekton.dev/v1alpha1
+kind: Pipeline
+metadata:
+  name: test-build-pipeline
+spec:
+  resources:
+    - name: git-source
+      type: git
+    - name: docker-image
+      type: image
+  tasks:
+    - name: build-task
+      taskRef:
+        name: nodejs-express-build-task
+      resources:
+      inputs:
+        - name: git-source
+          resource: git-source
+      outputs:
+        - name: docker-image
+          resource: docker-image
+----
+
+Now, run the following command to create the pipeline:
+----
+oc apply -f test-build-pipeline.yaml -n Kabanero
+----
+
+In the command, the `-n` indicates the Kabanero namespace where the pipeline is created.
+
+=== Create the PipelineRun binary
+*Note:* You can use a project of your choice to complete this guide. If you don’t have a project yet, run the `appsody init nodejs-express` command to get a sample Node.js - Express application.
+
+Go to the Kabanero Foundation project that you cloned and open the `scripts/appsody-Tekton-example-manual-run.sh` file. In this file, edit the `DOCKER_IMAGE` and `APP_REPO` parameters to reflect the code repository and image repository of your choice. For this example, use the Docker repository on OpenShift.
+
+Run the following command to create a PiplineRun binary:
+----
+./appsody-Tekton-example-manual-run.sh
+----
+
+Run the following command to see the running PipelineRuns:
+----
+oc get pipelinerun
+----
+
+Run the following command to display the PipelineRun execution steps:
+----
+oc get pipelinerun-o yaml
+----
+
+If the `pipeline-run` command fails at `validate-collection-is-activestep`, remove `appsody/nodejs-express:<ver>` and add `Kabanero/nodejs-express:<ver>` in the `appsody-config.yaml` file under the Appsody project.
+
+This problem is a known issue for projects that are created by using the `appsody-init` command.
+
+=== Create an image and push it to Docker
+Log in to your OpenShift dashboard and select the Kabanero namespace. Navigate to Overview -> Builds -> `<project-name>`, where `<project-name>` is your GitHub project name. You can now see the image that you created.
+
+== Deploy an image with Jenkins
+
+=== Create a Jenkinsfile
+Use the Jenkinsfile template from the reference section of this guide, and change the Docker Hub source to your own image repository. Push this Jenkinsfile to your GitHub repository in the root location.
+
+=== Create a deploy file
+On your local environment where Appsody is installed, go to your project folder and run the following command to generate an `app-deploy.yaml` file:
+----
+runappsody-deploy –-generate-only
+----
+
+Other tools, including Jenkins, can use this file for application deployment. Commit and push this file to the root of your project. Jenkins creates the `AppsodyApplication` resource in the OpenShift cluster and uses Appsody to deploy the application by using `app-deploy.yaml` file.
+
+=== Create a Jenkins project and pipeline
+Create a Jenkins (Ephemeral) instance from the OpenShift Catalog. Create a project and specify GitHub as the source. Provide your GitHub account and repository details and choose multi-branch pipeline creation. Jenkins automatically detects the Jenkinsfile in your GitHub repository and starts the deployment process.
+
+=== Verify deployment
+Go to Application -> Deployment in your OpenShift portal to see the successful deployment. You can also see the URL of running application by going to Application -> Deployment -> Routes.
+
+== Reference
+* The following file is a sample Jenkinsfile that you can use to set up your initial Jenkinsfile for the guide:
+----
+podTemplate(label: 'label', cloud: 'openshift', serviceAccount: 'appsody-sa', containers: [
+    containerTemplate(name: 'kubectl', image: 'lachlanevenson/k8s-kubectl', ttyEnabled: true, command: 'cat')
+  ]){
+    node('label') {
+        stage('Deploy') {
+            container('kubectl') {
+                checkout scm
+                sh 'sed -i -e \'s#applicationImage: .*$#applicationImage: docker-registry.default.svc:5000/Kabanero/project1#g\' app-deploy.yaml'
+                sh 'cat app-deploy.yaml'
+                sh 'find . -name app-deploy.yaml -type f|xargs kubectl apply -f'
+            }
+        }
+    }
+}
+----

--- a/README.adoc
+++ b/README.adoc
@@ -147,7 +147,7 @@ Run the following command to display the PipelineRun execution steps:
 oc get pipelinerun -o yaml
 ----
 
-If the `pipeline-run` command fails at `validate-collection-is-activestep`, remove the `appsody/nodejs-express:<ver>` value and add the `Kabanero/nodejs-express:<ver>` value in the `appsody-config.yaml` file under the Appsody project.
+If the `pipeline-run` command fails at the `validate-collection-is-active` step, remove the `appsody/nodejs-express:<ver>` value and add the `Kabanero/nodejs-express:<ver>` value in the `appsody-config.yaml` file under the Appsody project.
 
 This problem is a known issue for projects that are created by using the `appsody-init` command.
 

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,20 @@
 ---
 permalink: /guides/jenkins-integration-with-kabanero/
 ---
+// Copyright 2019 IBM Corporation and others.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 :page-layout: guide
 :page-duration: 30 minutes
 :page-releasedate: 2019-10-24

--- a/README.adoc
+++ b/README.adoc
@@ -147,7 +147,7 @@ Run the following command to display the PipelineRun execution steps:
 oc get pipelinerun-o yaml
 ----
 
-If the `pipeline-run` command fails at `validate-collection-is-activestep`, remove `appsody/nodejs-express:<ver>` and add `Kabanero/nodejs-express:<ver>` in the `appsody-config.yaml` file under the Appsody project.
+If the `pipeline-run` command fails at `validate-collection-is-activestep`, remove the `appsody/nodejs-express:<ver>` value and add the `Kabanero/nodejs-express:<ver>` value in the `appsody-config.yaml` file under the Appsody project.
 
 This problem is a known issue for projects that are created by using the `appsody-init` command.
 

--- a/README.adoc
+++ b/README.adoc
@@ -55,7 +55,7 @@ The script to create a pipeline is included with the Kabanero Pipelines project.
 Go to the `kabanero-pipelines` folder that you recently cloned. Find the `pipelines/incubator/build-deploy-pipeline.yaml` file, and remove the section of the file that is highlighted:
 
 // image::/img/guide/test-build-pipeline.png[link="/img/guide/test-build-pipeline.png" alt=""]
-[source,yaml,highlight=68..77]
+[source,yaml,highlight=81..90]
 ----
 apiVersion: Tekton.dev/v1alpha1
 kind: Pipeline


### PR DESCRIPTION
@dewan-ahmed @anneqm This PR incorporates all my changes from an ID perspective. I have a few notes/comments that we can work together on: 

- Read through the new guide and see how everything reads to you. 
- I _tried_ to find a way to highlight a portion of the `pipelines/incubator/build-deploy-pipeline.yaml` file in the first example, but I'm not sure that it worked. We're going to have to see how that builds to the Kabanero site. 
- What are `appsody/nodejs-express:<ver>` and `Kabanero/nodejs-express:<ver>` in the sentence, "If the `pipeline-run` command fails at `validate-collection-is-activestep`, remove `appsody/nodejs-express:<ver>` and add `Kabanero/nodejs-express:<ver>`..."? I think we need nouns following these to make this sentence clearer.
- In the **Create an image and push it to Docker** subtopic, is the user actually pushing to Docker in this section? I didn't see anything about Docker in the section, (but I've also never done this, so I'm not completely sure here.)
- I think linking to the "OpenShift Catalog" could be good. Where should this point the user? 

We can either discuss these changes, and I can push the updates to this PR, or we can merge this PR to view it on the Kabanero draft site and open a new PR for further changes. Let me know!